### PR TITLE
[DO NOT MERGE] fix: use pull_request_target

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -14,7 +14,7 @@ reviewers:
 
 # A number of reviewers added to the pull request
 # Set 0 to add all the reviewers (default: 0)
-numberOfReviewers: 0
+numberOfReviewers: 4
 
 # A list of assignees, overrides reviewers if set
 # assignees:

--- a/.github/workflows/auto_assign_reviewer.yml
+++ b/.github/workflows/auto_assign_reviewer.yml
@@ -1,5 +1,5 @@
 name: 'Auto Assign'
-on: pull_request
+on: pull_request_target
 
 jobs:
   add-reviews:

--- a/.github/workflows/auto_assign_reviewer.yml
+++ b/.github/workflows/auto_assign_reviewer.yml
@@ -1,7 +1,5 @@
 name: 'Auto Assign'
-on:
-  pull_request:
-    types: [opened]
+on: pull_request
 
 jobs:
   add-reviews:

--- a/.github/workflows/auto_assign_reviewer.yml
+++ b/.github/workflows/auto_assign_reviewer.yml
@@ -5,6 +5,7 @@ jobs:
   add-reviews:
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v1.1.2
+      - uses: kentaro-m/auto-assign-action@v1.1.1
         with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
           configuration-path: ".github/auto_assign.yml" # Only needed if you use something other than .github/auto_assign.yml

--- a/.github/workflows/auto_assign_reviewer.yml
+++ b/.github/workflows/auto_assign_reviewer.yml
@@ -1,14 +1,13 @@
 name: 'Auto Assign'
 on:
   pull_request:
-    branches:
-      - main  # Set a branch to deploy
+    types: [opened]
 
 jobs:
   add-reviews:
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v1.1.2
+      - uses: bubkoo/auto-assign@v1 # kentaro-m/auto-assign-action@v1.1.2
         with:
-          repo-token: '${{ secrets.GITHUB_TOKEN }}'
-          configuration-path: ".github/auto_assign.yml" # Only needed if you use something other than .github/auto_assign.yml
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          CONFIG_FILE: ".github/auto_assign.yml" # configuration-path: ".github/auto_assign.yml"

--- a/.github/workflows/auto_assign_reviewer.yml
+++ b/.github/workflows/auto_assign_reviewer.yml
@@ -1,11 +1,14 @@
 name: 'Auto Assign'
-on: pull_request_target
+on:
+  pull_request:
+    branches:
+      - main  # Set a branch to deploy
 
 jobs:
   add-reviews:
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v1.1.1
+      - uses: kentaro-m/auto-assign-action@v1.1.2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           configuration-path: ".github/auto_assign.yml" # Only needed if you use something other than .github/auto_assign.yml


### PR DESCRIPTION
暂时别合并

Fix according to https://github.com/kentaro-m/auto-assign-action/issues/29